### PR TITLE
initial stab at submitting image/attachment formData via bureaucracy

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/bevacqua/woofmark",
   "dependencies": {
     "bullseye": "1.4.6",
-    "bureaucracy": "1.0.5",
+    "bureaucracy": "1.0.6",
     "crossvent": "1.5.0",
     "kanye": "3.0.2",
     "local-storage": "1.4.2",

--- a/readme.markdown
+++ b/readme.markdown
@@ -209,6 +209,9 @@ If you wish to set up file uploads, _in addition to letting the user just paste 
   // endpoint where the images will be uploaded to, required
   url: '/uploads',
 
+  // optional additional form submission data, passed to bureaucracy
+  formData: { description: 'A new image' },
+
   // optional text describing the kind of files that can be uploaded
   restriction: 'GIF, JPG, and PNG images',
 

--- a/src/prompts/prompt.js
+++ b/src/prompts/prompt.js
@@ -110,6 +110,7 @@ function prompt (options, done) {
 
     var bureaucrat = bureaucracy.setup(domup.fileinput, {
       method: upload.method,
+      formData: upload.formData,
       endpoint: upload.url,
       validate: 'image'
     });


### PR DESCRIPTION
This is a first-draft attempt to solve #38 -- not sure if it's architecturally the right approach, but I believe it will pass a `formData` object from the `images` method all the way to the `bureaucracy` v1.0.6, and it will get appended to the form submission. How does this look? 
