### PR TITLE
xhrOptions options param to pass to bureaucracy

### DIFF
--- a/readme.markdown
+++ b/readme.markdown
@@ -212,8 +212,11 @@ If you wish to set up file uploads, _in addition to letting the user just paste 
   // image field key, passed to bureaucracy, which defaults to 'uploads'
   fieldKey: 'uploads',
 
-  // optional additional form submission data, passed to bureaucracy
+  // optional additional form submission data, passed to `bureaucracy`
   formData: { description: 'A new image' },
+
+  // optional options for `xhr` upload request, passed to `bureaucracy`
+  xhrOptions: { headers: {} },
 
   // optional text describing the kind of files that can be uploaded
   restriction: 'GIF, JPG, and PNG images',

--- a/src/prompts/prompt.js
+++ b/src/prompts/prompt.js
@@ -112,6 +112,7 @@ function prompt (options, done) {
       method: upload.method,
       formData: upload.formData,
       fieldKey: upload.fieldKey,
+      xhrOptions: upload.xhrOptions,
       endpoint: upload.url,
       validate: 'image'
     });


### PR DESCRIPTION
Pending https://github.com/bevacqua/bureaucracy/pull/6, this will allow attachment of `csrf` tokens (or other `xhr` configuration) in `woofmark`. 
