### PR TITLE
Add CSS File to Bower `main`

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,10 @@
   "name": "woofmark",
   "version": "4.2.3",
   "description": "Barking up the DOM tree. A modular, progressive, and beautiful Markdown and HTML editor",
-  "main": "dist/woofmark.js",
+  "main": [
+    "dist/woofmark.js",
+    "dist/woofmark.css",
+  ],
   "homepage": "https://github.com/bevacqua/woofmark",
   "authors": [
     "Nicolas Bevacqua <nicolasbevacqua@gmail.com>"

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
   "description": "Barking up the DOM tree. A modular, progressive, and beautiful Markdown and HTML editor",
   "main": [
     "dist/woofmark.js",
-    "dist/woofmark.css",
+    "dist/woofmark.css"
   ],
   "homepage": "https://github.com/bevacqua/woofmark",
   "authors": [


### PR DESCRIPTION
[Wiredep](https://www.npmjs.com/package/wiredep) (and some other automated bower tools) rely on CSS files being included as part of the `main` configuration in the bower.json file. The bower.json spec also indicates that styles should be included if they should be used in conjunction with the file. So this just adds it to the bower.json file.